### PR TITLE
Populate planet weight state to prevent reference value reset

### DIFF
--- a/app/templates/configure.html
+++ b/app/templates/configure.html
@@ -198,6 +198,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 data.planets.forEach((planet, index) => {
                     const planetNormalizedName = normalizePlanetName(planet.name);
                     console.log(`Loading UI for planet: ${planet.name}, normalized: ${planetNormalizedName}`);
+                    let currentPlanetHabWeights = {};
+                    let currentPlanetPhiWeights = {};
                     html += `
                         <div class="card mb-3 planet-weight-card" data-planet-normalized-name="${planetNormalizedName}" data-planet-display-name="${planet.name}">
                             <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
@@ -218,6 +220,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                         <div class="row">`;
                     habFactorDefinitions.forEach(factor => {
                         const currentValue = getWeightValue(planetNormalizedName, 'hab', factor.key);
+                        currentPlanetHabWeights[factor.label] = currentValue;
                         html += `
                             <div class="col-md-6 mb-3">
                                 <label class="form-label">${factor.label}</label>
@@ -238,6 +241,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                     <div class="row">`;
                     phiFactorDefinitions.forEach(factor => {
                         const currentValue = getWeightValue(planetNormalizedName, 'phi', factor.key);
+                        currentPlanetPhiWeights[factor.label] = currentValue;
                         html += `
                             <div class="col-md-6 mb-3">
                                 <label class="form-label">${factor.label}</label>
@@ -259,6 +263,11 @@ document.addEventListener('DOMContentLoaded', function() {
                                 <button type="button" class="btn btn-success save-individual-weights-btn" data-planet-normalized-name="${planetNormalizedName}" data-planet-display-name="${planet.name}">Save ${planet.name} Weights</button>
                             </div>
                         </div>`;
+
+                    CURRENT_PLANET_SPECIFIC_WEIGHTS[planetNormalizedName] = {
+                        habitability: currentPlanetHabWeights,
+                        phi: currentPlanetPhiWeights
+                    };
                 });
                 planetWeightsContainer.innerHTML = html;
                 setupPlanetWeightControls();


### PR DESCRIPTION
## Summary
- ensure planet-specific weight state is populated for all planets when loading the configure page
- fix reference values table resetting the last planet's scores to 100%

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf98349cf08329943e3b5a6bfcfc24