### PR TITLE
Fix PHI baselines on configure page

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -313,6 +313,8 @@ def configure():
     default_phi_weights = DEFAULT_PHI_WEIGHTS
     current_global_hab_weights = session.get("habitability_weights", ZERO_HABITABILITY_WEIGHTS)
     current_global_phi_weights = session.get("phi_weights", ZERO_PHI_WEIGHTS)
+    has_global_hab_weights = "habitability_weights" in session
+    has_global_phi_weights = "phi_weights" in session
     stored_planet_specific_weights = session.get("planet_weights", {})
     use_individual = session.get("use_individual_weights", False)
 
@@ -322,8 +324,35 @@ def configure():
     if planet_names_list:
         default_habitability_weights_ref = current_app.config.get("DEFAULT_HABITABILITY_WEIGHTS", DEFAULT_HABITABILITY_WEIGHTS)
         default_phi_weights_ref = current_app.config.get("DEFAULT_PHI_WEIGHTS", DEFAULT_PHI_WEIGHTS)
-        global_habitability_weights_ref = session.get("habitability_weights", ZERO_HABITABILITY_WEIGHTS)
-        global_phi_weights_ref = session.get("phi_weights", ZERO_PHI_WEIGHTS)
+
+        raw_global_habitability_weights = session.get("habitability_weights") if has_global_hab_weights else {}
+        raw_global_phi_weights = session.get("phi_weights") if has_global_phi_weights else {}
+
+        global_habitability_overrides = sanitize_weight_payload(
+            raw_global_habitability_weights,
+            {},
+            HAB_WEIGHT_MIN,
+            HAB_WEIGHT_MAX,
+        )
+        global_phi_overrides = sanitize_weight_payload(
+            raw_global_phi_weights,
+            {},
+            PHI_WEIGHT_MIN,
+            PHI_WEIGHT_MAX,
+        )
+
+        reference_habitability_weights = combine_weight_sources(
+            default_habitability_weights_ref,
+            global_habitability_overrides,
+            clamp_min=HAB_WEIGHT_MIN,
+            clamp_max=HAB_WEIGHT_MAX,
+        )
+        reference_phi_weights = combine_weight_sources(
+            default_phi_weights_ref,
+            global_phi_overrides,
+            clamp_min=PHI_WEIGHT_MIN,
+            clamp_max=PHI_WEIGHT_MAX,
+        )
         
         hwc_df = load_hwc_catalog(os.path.join(current_app.config["DATA_DIR"], "hwc.csv"))
         hz_gallery_df = load_hzgallery_catalog(os.path.join(current_app.config["DATA_DIR"], "table-hzgallery.csv"))
@@ -344,12 +373,14 @@ def configure():
             
             logger.debug(f"Combined data for {normalized_planet_name}: {combined_data}")
             
-            # Calcular ESI e PHI com pesos padrão (0.0 para habitability, 0.0 para PHI)
+            # Calcular ESI e PHI utilizando pesos de referência
             processed_result = process_planet_data(
                 normalized_planet_name,
                 combined_data,
-                {"habitability": {"Size": 0.0, "Density": 0.0, "Habitable Zone": 0.0}, 
-                 "phi": {"Solid Surface": 0.0, "Stable Energy": 0.0, "Life Compounds": 0.0, "Stable Orbit": 0.0}}
+                {
+                    "habitability": dict(reference_habitability_weights),
+                    "phi": dict(reference_phi_weights),
+                }
             )
             
             if processed_result:

--- a/app/templates/configure.html
+++ b/app/templates/configure.html
@@ -202,15 +202,68 @@ document.addEventListener('DOMContentLoaded', function() {
         return rounded;
     }
 
-    function getBaselineWeight(planetNormalizedName, category, displayNameKey) {
+    function getBaselineWeight(planetNormalizedName, category, displayNameKey, weightKey) {
         const source = category === 'hab' ? INITIAL_HAB_WEIGHTS : INITIAL_PHI_WEIGHTS;
-        const planetMap = source[planetNormalizedName] || {};
-        if (planetMap[displayNameKey] !== undefined) {
-            return Number(planetMap[displayNameKey]);
-        }
         const defaults = category === 'hab' ? DEFAULT_HAB_WEIGHTS : DEFAULT_PHI_WEIGHTS;
-        const fallback = defaults[displayNameKey];
-        return fallback !== undefined ? Number(fallback) : 0.0;
+        const planetMap = (source && source[planetNormalizedName]) || {};
+        const candidates = [];
+        const addCandidate = (key) => {
+            if (typeof key !== 'string') return;
+            const normalized = key.trim();
+            if (!normalized) return;
+            if (!candidates.includes(normalized)) {
+                candidates.push(normalized);
+            }
+        };
+
+        addCandidate(displayNameKey);
+        if (typeof displayNameKey === 'string') {
+            addCandidate(displayNameKey.replace(/\s+/g, '_'));
+            addCandidate(displayNameKey.replace(/\s+/g, '').toLowerCase());
+        }
+        addCandidate(weightKey);
+        if (typeof weightKey === 'string') {
+            addCandidate(weightKey.replace(/_/g, ' '));
+            addCandidate(weightKey.replace(/_/g, '').toLowerCase());
+        }
+
+        const lookupValue = (map, candidate) => {
+            if (!map || typeof map !== 'object' || typeof candidate !== 'string') {
+                return undefined;
+            }
+            if (Object.prototype.hasOwnProperty.call(map, candidate)) {
+                return map[candidate];
+            }
+            const loweredCandidate = candidate.toLowerCase();
+            for (const key of Object.keys(map)) {
+                if (typeof key === 'string' && key.toLowerCase() === loweredCandidate) {
+                    return map[key];
+                }
+            }
+            return undefined;
+        };
+
+        for (const candidate of candidates) {
+            const value = lookupValue(planetMap, candidate);
+            if (value !== undefined) {
+                const numeric = Number(value);
+                if (Number.isFinite(numeric)) {
+                    return numeric;
+                }
+            }
+        }
+
+        for (const candidate of candidates) {
+            const value = lookupValue(defaults, candidate);
+            if (value !== undefined) {
+                const numeric = Number(value);
+                if (Number.isFinite(numeric)) {
+                    return numeric;
+                }
+            }
+        }
+
+        return category === 'phi' ? 0.25 : 1.0;
     }
 
     function getEffectiveWeight(planetNormalizedName, category, displayNameKey, baselineValue) {
@@ -351,7 +404,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                     <div class="tab-pane fade show active" id="hab-content-${index}" role="tabpanel">
                                         <div class="row">`;
                     habFactorDefinitions.forEach(factor => {
-                        const baselineValue = getBaselineWeight(planetNormalizedName, 'hab', factor.label);
+                        const baselineValue = getBaselineWeight(planetNormalizedName, 'hab', factor.label, factor.key);
                         const effectiveValue = getEffectiveWeight(planetNormalizedName, 'hab', factor.label, baselineValue);
                         const { deltaMin, deltaMax, zeroPercent } = computeDeltaRange(baselineValue, factor.absMin, factor.absMax, factor.step);
                         let deltaValue = roundToStep(effectiveValue - baselineValue, factor.step);
@@ -393,7 +446,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                 <div class="tab-pane fade" id="phi-content-${index}" role="tabpanel">
                                     <div class="row">`;
                     phiFactorDefinitions.forEach(factor => {
-                        const baselineValue = getBaselineWeight(planetNormalizedName, 'phi', factor.label);
+                        const baselineValue = getBaselineWeight(planetNormalizedName, 'phi', factor.label, factor.key);
                         const effectiveValue = getEffectiveWeight(planetNormalizedName, 'phi', factor.label, baselineValue);
                         const { deltaMin, deltaMax, zeroPercent } = computeDeltaRange(baselineValue, factor.absMin, factor.absMax, factor.step);
                         let deltaValue = roundToStep(effectiveValue - baselineValue, factor.step);


### PR DESCRIPTION
## Summary
- ensure configure reference calculations combine default and global weights before building PHI baselines
- normalize planet weight key lookups on the configure UI so PHI sliders resolve baseline values and default to sensible fallbacks

## Testing
- pytest *(fails: pre-existing lifesearch_main and weight recalculation failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3a6a5f6c83298c7ce9d2acfcddd9